### PR TITLE
Make current folder read only for enhanced security

### DIFF
--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -78,9 +78,11 @@ commands:
   new:
     - make
     - backup
+    - shell: chmod -R ug+w current
     - purge
     - finalize
     - shell: cp conf/_ping.php current
+    - shell: chmod -R a-w current
     - install
 
 
@@ -88,9 +90,11 @@ commands:
   update:
     - make
     - backup
+    - shell: chmod -R ug+w current
     - shell: unlink current/sites/default/files
     - finalize
     - shell: cp conf/_ping.php current
+    - shell: chmod -R a-w current
     - update
 
   # This is just an example on how to create custom commands,
@@ -114,6 +118,8 @@ commands:
 
   hotfix:
     - link
+    - shell: chmod -R ug+w current
     - shell: rsync -a _build/ current
     - shell: rm -r _build
+    - shell: chmod -R a-w current
     - update


### PR DESCRIPTION
For enhanced security it's best to have the current folder (minus files folder) as a read only folder because Drupal/web server does not need write access to Drupal source code.