### PR TITLE
Make drupal build.sh optional for custom setups.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,10 +76,8 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
     fi
   fi
 
-  read -p "Would you like to download the latest build.sh?" -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    # Get & update drupal/build.sh
+  # If it is enabled in project.yml - get & update drupal/build.sh
+  if $buildsh_enabled; then
     if [ -n "$buildsh_revision" ]; then
       curl -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_revision/build.sh
     else

--- a/build.sh
+++ b/build.sh
@@ -76,11 +76,15 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
     fi
   fi
 
-  # Get & update drupal/build.sh
-  if [ -n "$buildsh_revision" ]; then
-    curl -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_revision/build.sh
-  else
-    curl -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_branch/build.sh
+  read -p "Would you like to download the latest build.sh?" -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    # Get & update drupal/build.sh
+    if [ -n "$buildsh_revision" ]; then
+      curl -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_revision/build.sh
+    else
+      curl -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_branch/build.sh
+    fi
   fi
 
   # Ensure drush aliases file is linked

--- a/conf/project.yml
+++ b/conf/project.yml
@@ -5,6 +5,6 @@ ansible:
   branch: master
   revision:
 buildsh:
-  enabled: false
+  enabled: true
   branch: develop
   revision:

--- a/conf/project.yml
+++ b/conf/project.yml
@@ -2,8 +2,9 @@ project:
   name: ansibleref
 ansible:
   remote: git@github.com:wunderkraut/WunderMachina.git
-  branch: master 
-  revision: 
+  branch: master
+  revision:
 buildsh:
+  enabled: false
   branch: develop
   revision:


### PR DESCRIPTION
In some cases one would like to use Wundertools as a base for a project but one might not necessarily need the drupal/build.sh script - for example project might not have site.make file or it's some kind of unique setup. So how about we make the download/update optional?

Here is a patch for a start. 