### PR TITLE
Add option to not include build.sh. Use no_include=1 value in buildsh yml config to exclude build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,11 +76,13 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
     fi
   fi
 
-  # Get & update drupal/build.sh
-  if [ -n "$buildsh_revision" ]; then
-    curl -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_revision/build.sh
-  else
-    curl -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_branch/build.sh
+  if [ -z "$buildsh_no_include" ]; then
+    # Get & update drupal/build.sh
+    if [ -n "$buildsh_revision" ]; then
+      curl -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_revision/build.sh
+    else
+      curl -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_branch/build.sh
+    fi
   fi
 
   # Ensure drush aliases file is linked
@@ -89,4 +91,3 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
     ln -s $ALIASPATH $ALIASTARGET
   fi
 fi
-


### PR DESCRIPTION
Reason: 
Some projects have custom build.sh scripts
Other projects use custom scripts for making and building projects