### PR TITLE
Add some more Suhosin variables to prevent 402 error when editing views.

### DIFF
--- a/conf/variables.yml
+++ b/conf/variables.yml
@@ -77,6 +77,10 @@ php:
 #       val: 1000
 #     - key: suhosin.request.max_vars
 #       val: 1000
+#     - key: suhosin.request.max_array_index_length
+#       val: 2048
+#     - key: suhosin.post.max_array_index_length
+#       val: 1024
  - section: OPCACHE
    options:
     - key: opcache.memory


### PR DESCRIPTION
When using php 5.3 opening any views edit page user is presented with 402 error. Let's add some more configuration variables to prevent this.