### PR TITLE
Feature/use public repo url

### DIFF
--- a/conf/project.yml
+++ b/conf/project.yml
@@ -1,7 +1,7 @@
 project:
   name: ansibleref
 ansible:
-  remote: git@github.com:wunderkraut/WunderMachina.git
+  remote: https://github.com/wunderkraut/WunderMachina.git
   branch: master
   revision:
 buildsh:


### PR DESCRIPTION
Persons should access through HTTPS git link, so anyone can get the pull to work.