### PR TITLE
Added a setup to check out ansible branch if it has changed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -115,6 +115,7 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
     if [ -z "$ansible_revision" ]; then
       cd $ROOT/ansible
       git pull
+      git checkout $ansible_branch
       cd $ROOT
     fi
   fi
@@ -143,4 +144,3 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
     fi
   fi
 fi
-


### PR DESCRIPTION
If ansible (WunderMachina for example) branch is changed after the project is already setup the first time the change isn't affected. This small fix makes sure we always have the correct branch of ansible. Provisioning still needs to be done manually after branch change.