### PR TITLE
Added the files folder in a way that it's contents get ignored

### DIFF
--- a/drupal/files/.gitignore
+++ b/drupal/files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
When setting up a new project based on WunderTools the files folder under drupal is missing, but there is also no instructions in the readme to create it. Figured it would be more useful to include the folder instead of instructions.