### PR TITLE
Added copying of _ping.php into place to all the environments because

### DIFF
--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -41,6 +41,7 @@ default:
     - code/themes: sites/all/themes/custom
     - code/profiles/wk: profiles/wk
     - conf/local.settings.php: sites/default/settings.php
+    - conf/_ping.php: _ping.php
 
 # Test environment:
 test:
@@ -60,6 +61,7 @@ test:
     - code/themes: sites/all/themes/custom
     - code/profiles/wk: profiles/wk
     - conf/test.settings.php: sites/default/settings.php
+    - conf/_ping.php: _ping.php
 
   # We can provide local commands or override global ones.
   local_commands:
@@ -83,3 +85,4 @@ production:
     - code/themes: sites/all/themes/custom
     - code/profiles/wk: profiles/wk
     - conf/prod.settings.php: sites/default/settings.php
+    - conf/_ping.php: _ping.php


### PR DESCRIPTION
Added copying of _ping.php into place to all the environments because that is a requirement for varnish to work.