### PR TITLE
Enable local PHP development by default

### DIFF
--- a/conf/vagrant.yml
+++ b/conf/vagrant.yml
@@ -51,6 +51,12 @@
     php_memory_limit: 256 # In MB
     nginx_workers: 2 # This should be equal to core count
 
+    # Make sure changes to PHP files are not ignored
+    php_ini:
+      - section: OPCACHE
+        options:
+          - key: opcache.validate_timestamps
+            val: 1 
 
     # </EXAMPLE>
 


### PR DESCRIPTION
Added a small configuration to the vagrant PHP. This was so that local development is possible without restarting php-fpm with every file change to clear opcache. It comes with a small performance hit, but I think it's the best of both worlds and better than disabling opcache completely for example.