### PR TITLE
Added functionality to always reset the ansible to the revision

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -117,6 +117,10 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
       git pull
       git checkout $ansible_branch
       cd $ROOT
+    else
+      cd $ROOT/ansible
+      git reset --hard $ansible_revision
+      cd $ROOT
     fi
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -119,6 +119,7 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
       cd $ROOT
     else
       cd $ROOT/ansible
+      git pull
       git reset --hard $ansible_revision
       cd $ROOT
     fi


### PR DESCRIPTION
Added functionality to always reset the ansible to the revision in the config. This allows us to update the revision in the project and it gets updated for all developers. Of course provisioning is still needed after an update, but that can be then done manually.