### PR TITLE
Update d8 branch to WunderTools version 8.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+8
+varnish.control_key variable added (optional). This will set up a Varnish control key in
+/etc/varnish/secret and makes it a php environment variable for use in
+vagrant.settings.php. Check vagrant.settings.php for Varnish 4 compatible
+settings.
+
 7
 hash_behaviour changed to merge so that you don't need to copy the whole dict object from defaults when you just want to override some of the values in it.
 To comply with this add "hash_behaviour=merge" to projects ansible.cfg file.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 roles_path=./local_ansible_roles:./ansible/playbook/roles
+hash_behaviour=merge

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ function parse_yaml {
 
 # Remember to update this on each release
 # Also update the changelog!
-VERSION=7
+VERSION=8
 
 pushd `dirname $0` > /dev/null
 ROOT=`pwd -P`


### PR DESCRIPTION
Right now I didn't add that varnish.control_key here, should we do that too? Even if it is optional. 