### PR TITLE
Make site.yml use a settings.php file that exists in the repo.

### DIFF
--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -40,7 +40,7 @@ default:
     - code/modules: sites/all/modules/custom
     - code/themes: sites/all/themes/custom
     - code/profiles/wk: profiles/wk
-    - conf/local.settings.php: sites/default/settings.php
+    - conf/vagrant.settings.php: sites/default/settings.php
     - conf/_ping.php: _ping.php
 
 # Test environment:


### PR DESCRIPTION
This fixes an error from./build.sh new for people who just download &
run vagrant up without configuring anything: 

```** BUILD ERROR: "Can't link conf/local.settings.php to /vagrant/drupal/_build/sites/default/settings.php. Make sure that the source exists."```