### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[composer.json]
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,8 @@ insert_final_newline = true
 
 [composer.json]
 indent_size = 4
+
+[*.py]
+# Four-space indentation
+indent_size = 4
+indent_style = space


### PR DESCRIPTION
Use EditorConfig to help maintain consistent coding standards.

Some editors have it built in, most others have an easy to add plugin: http://editorconfig.org

You can add different rules for different file masks, if necessary.

This one is taken from http://cgit.drupalcode.org/drupal/tree/.editorconfig with the Python standard added.
