### PR TITLE
Add an example configuration file for a simpler local setup

### DIFF
--- a/conf/vagrant_simple.yml
+++ b/conf/vagrant_simple.yml
@@ -1,0 +1,100 @@
+---
+
+- hosts: default
+  become: true
+  become_method: sudo
+  user: vagrant
+  roles:
+   - { role: base, tags: [ 'base' ] }
+   - { role: php-fpm, tags: [ 'php-fpm' ] }
+   - { role: nginx, tags: [ 'nginx' ] }
+   - { role: varnish, tags: [ 'varnish' ] }
+   - { role: memcached, tags: [ 'memcached' ] }
+   - { role: drush, tags: [ 'drush' ] }
+   - { role: dbserver, tags: [ 'dbserver' ] }
+   - { role: drupal-db, tags: [ 'drupal-db' ] }
+   # Local replacement for letsencrypt. Uses letsencrypt settings but creates self signed certificates for local use.
+   # Devtools, uncomment to enable xdebug and blackfire
+   # To use blackfire you need to define blackfire keys and tokens (see ansible/playbook/roles/devtools/defaults/main.yml for reference)
+   # You can get those keys and tokens from https://blackfire.io/docs/up-and-running/installation
+   # Otherwise you can disable blackfire by setting enable_blackfire: false
+   # - { role: devtools, tags: [ 'devtools' ] }
+   # Mailhog, uncomment to catch outgoing mail. You can access mailhog at your local site url on port 8025
+   - { role: mailhog, tags: [ 'mailhog' ] }
+   #- { role: mongodb, tags: [ 'mongodb' ] }
+
+  tasks:
+
+    - cron: name="check dirs" minute="0" hour="5,2" job="ls -alh > /dev/null"
+
+  vars:
+    wkv_site_env: local
+
+    nginx_disable_content_security_policy: True
+
+    partition_var_log: False
+
+    partition_var_lib_mysql: False
+ 
+    # <EXAMPLE>
+    # How to assign memory for each role and set the correct
+    # amount of worker processes / threads
+
+    memory_db: 1024 # In MB
+    memory_app: 1024 # In MB
+
+    # NOTE: ALWAYS leave some spare memory for the server
+    php_memory_limit: 256 # In MB
+    nginx_workers: 2 # This should be equal to core count
+
+    # Make sure changes to PHP files are not ignored
+    php_ini:
+      - section: OPCACHE
+        options:
+          - key: opcache.validate_timestamps
+            val: 1
+          - key: opcache.opcache.revalidate_freq
+            val: 0
+
+    # </EXAMPLE>
+
+    # Apps I want to run on this server
+    apps:
+      # For drupal 7
+      - server_name: local.wundertools.com
+        http_port: 8080
+        docroot: /vagrant/drupal/current
+
+    # This server also acts as a load balancer
+    varnish:
+      port: 80
+      memory: 512M
+      probe_resource_url: "_ping.php"
+      control_key: "{{ 'vagrant' | to_uuid }}"
+      acl_internal:
+        - ip: 127.0.0.1
+      acl_purge:
+        - ip: 127.0.0.1
+      acl_upstream_proxy:
+        - ip: 127.0.0.1
+      directors:
+        - name: wundertools 
+          host: local.wundertools.com 
+          backends:
+            - name: local_wundertools_http
+              address: 127.0.0.1
+              port: 8080
+
+    httpforwards:
+      - server_name: local.wundertools.com 
+        forwarded_domains: 'local.wundertools.com'
+
+    # Databases
+    databases:
+      - name: drupal
+        user: drupal
+        pass: password
+        hosts:
+          - "127.0.0.1"
+          - "::1"
+          - "localhost"


### PR DESCRIPTION
In many legacy projects, there is no need for ssl support. This is a starting point
for a simpler local environment.
