### PR TITLE
Feature/custom WunderTools repository

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,18 @@
+9
+(optional) WunderTools now supports having a custom repository for WunderTools
+and build.sh (only on GitHub for now). To use it, create a fork of WunderTools
+and/or build.sh, add your repo url and branches to conf/project.yml, here is an
+example:
+
+buildsh:
+  enabled: true
+  branch: develop
+  repository: badrange/build.sh
+  revision:
+wundertools:
+  repository: badrange/WunderTools
+  branch: feature/custom-wundertools-repository
+
 8
 varnish.control_key variable added (optional). This will set up a Varnish control key in
 /etc/varnish/secret and makes it a php environment variable for use in
@@ -30,6 +45,6 @@ externaldrupal:
   remote: [external drupal repository url]
   branch: [branch to use from the external repository]
 Repository should have drupal installation directly under the repository root.
-  
+
 1
 Added support for managed version updates for build.sh

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,18 +1,3 @@
-9
-(optional) WunderTools now supports having a custom repository for WunderTools
-and build.sh (only on GitHub for now). To use it, create a fork of WunderTools
-and/or build.sh, add your repo url and branches to conf/project.yml, here is an
-example:
-
-buildsh:
-  enabled: true
-  branch: develop
-  repository: badrange/build.sh
-  revision:
-wundertools:
-  repository: badrange/WunderTools
-  branch: feature/custom-wundertools-repository
-
 8
 varnish.control_key variable added (optional). This will set up a Varnish control key in
 /etc/varnish/secret and makes it a php environment variable for use in
@@ -45,6 +30,6 @@ externaldrupal:
   remote: [external drupal repository url]
   branch: [branch to use from the external repository]
 Repository should have drupal installation directly under the repository root.
-
+  
 1
 Added support for managed version updates for build.sh

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ fi
 
 VERSIONFILE=$ROOT/VERSION
 CHANGELOG=$ROOT/CHANGELOG
-CHANGELOGURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/$GITBRANCH/CHANGELOG"
+CHANGELOGURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/CHANGELOG"
 
 if [ -f $VERSIONFILE ]; then
   typeset -i CURRENT_VERSION=$(<$VERSIONFILE)
@@ -92,7 +92,7 @@ if [[ $1 == "reset" ]]; then
 elif [[ $1 == "up" || $1 == "provision" ]]; then
   # First we check if there is update for this script
   SELF=$(basename $0)
-  UPDATEURL="https://raw.githubusercontent.com/badrange/WunderTools/$GITBRANCH/build.sh"
+  UPDATEURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/$GITBRANCH/build.sh"
   MD5SELF=$($MD5COMMAND $0 | awk '{print $1}')
   MD5LATEST=$(curl -s $UPDATEURL | $MD5COMMAND | awk '{print $1}')
   if [[ "$MD5SELF" != "$MD5LATEST" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -37,9 +37,16 @@ else
   GITBRANCH=$wundertools_branch
 fi
 
+if [ -z "$wundertools_repository" ]; then
+  WUNDERTOOLSREPOSITORY="wunderkraut/WunderTools"
+else
+  WUNDERTOOLSREPOSITORY=$wundertools_repository
+fi
+
+
 VERSIONFILE=$ROOT/VERSION
 CHANGELOG=$ROOT/CHANGELOG
-CHANGELOGURL="https://raw.githubusercontent.com/wunderkraut/WunderTools/$GITBRANCH/CHANGELOG"
+CHANGELOGURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/$GITBRANCH/CHANGELOG"
 
 if [ -f $VERSIONFILE ]; then
   typeset -i CURRENT_VERSION=$(<$VERSIONFILE)
@@ -85,7 +92,7 @@ if [[ $1 == "reset" ]]; then
 elif [[ $1 == "up" || $1 == "provision" ]]; then
   # First we check if there is update for this script
   SELF=$(basename $0)
-  UPDATEURL="https://raw.githubusercontent.com/wunderkraut/WunderTools/$GITBRANCH/build.sh"
+  UPDATEURL="https://raw.githubusercontent.com/badrange/WunderTools/$GITBRANCH/build.sh"
   MD5SELF=$($MD5COMMAND $0 | awk '{print $1}')
   MD5LATEST=$(curl -s $UPDATEURL | $MD5COMMAND | awk '{print $1}')
   if [[ "$MD5SELF" != "$MD5LATEST" ]]; then
@@ -128,9 +135,9 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
   # If it is enabled in project.yml - get & update drupal/build.sh
   if $buildsh_enabled; then
     if [ -n "$buildsh_revision" ]; then
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_revision/build.sh
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/badrange/build.sh/$buildsh_revision/build.sh
     else
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_branch/build.sh
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/badrange/build.sh/$buildsh_branch/build.sh
     fi
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -37,16 +37,9 @@ else
   GITBRANCH=$wundertools_branch
 fi
 
-if [ -z "$wundertools_repository" ]; then
-  WUNDERTOOLSREPOSITORY="wunderkraut/WunderTools"
-else
-  WUNDERTOOLSREPOSITORY=$wundertools_repository
-fi
-
-
 VERSIONFILE=$ROOT/VERSION
 CHANGELOG=$ROOT/CHANGELOG
-CHANGELOGURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/$GITBRANCH/CHANGELOG"
+CHANGELOGURL="https://raw.githubusercontent.com/wunderkraut/WunderTools/$GITBRANCH/CHANGELOG"
 
 if [ -f $VERSIONFILE ]; then
   typeset -i CURRENT_VERSION=$(<$VERSIONFILE)
@@ -92,7 +85,7 @@ if [[ $1 == "reset" ]]; then
 elif [[ $1 == "up" || $1 == "provision" ]]; then
   # First we check if there is update for this script
   SELF=$(basename $0)
-  UPDATEURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/$GITBRANCH/build.sh"
+  UPDATEURL="https://raw.githubusercontent.com/wunderkraut/WunderTools/$GITBRANCH/build.sh"
   MD5SELF=$($MD5COMMAND $0 | awk '{print $1}')
   MD5LATEST=$(curl -s $UPDATEURL | $MD5COMMAND | awk '{print $1}')
   if [[ "$MD5SELF" != "$MD5LATEST" ]]; then
@@ -134,15 +127,10 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
 
   # If it is enabled in project.yml - get & update drupal/build.sh
   if $buildsh_enabled; then
-    if [ -z "$buildsh_repository" ]; then
-      BUILDSHREPOSITORY="wunderkraut/build.sh"
-    else
-      BUILDSHREPOSITORY=$buildsh_repository
-    fi
     if [ -n "$buildsh_revision" ]; then
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$BUILDSHREPOSITORY/$buildsh_revision/build.sh
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_revision/build.sh
     else
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$BUILDSHREPOSITORY/$buildsh_branch/build.sh
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_branch/build.sh
     fi
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -37,9 +37,16 @@ else
   GITBRANCH=$wundertools_branch
 fi
 
+if [ -z "$wundertools_repository" ]; then
+  WUNDERTOOLSREPOSITORY="wunderkraut/WunderTools"
+else
+  WUNDERTOOLSREPOSITORY=$wundertools_repository
+fi
+
+
 VERSIONFILE=$ROOT/VERSION
 CHANGELOG=$ROOT/CHANGELOG
-CHANGELOGURL="https://raw.githubusercontent.com/wunderkraut/WunderTools/$GITBRANCH/CHANGELOG"
+CHANGELOGURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/$GITBRANCH/CHANGELOG"
 
 if [ -f $VERSIONFILE ]; then
   typeset -i CURRENT_VERSION=$(<$VERSIONFILE)
@@ -85,7 +92,7 @@ if [[ $1 == "reset" ]]; then
 elif [[ $1 == "up" || $1 == "provision" ]]; then
   # First we check if there is update for this script
   SELF=$(basename $0)
-  UPDATEURL="https://raw.githubusercontent.com/wunderkraut/WunderTools/$GITBRANCH/build.sh"
+  UPDATEURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/$GITBRANCH/build.sh"
   MD5SELF=$($MD5COMMAND $0 | awk '{print $1}')
   MD5LATEST=$(curl -s $UPDATEURL | $MD5COMMAND | awk '{print $1}')
   if [[ "$MD5SELF" != "$MD5LATEST" ]]; then
@@ -127,10 +134,15 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
 
   # If it is enabled in project.yml - get & update drupal/build.sh
   if $buildsh_enabled; then
-    if [ -n "$buildsh_revision" ]; then
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_revision/build.sh
+    if [ -z "$buildsh_repository" ]; then
+      BUILDSHREPOSITORY="wunderkraut/build.sh"
     else
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/wunderkraut/build.sh/$buildsh_branch/build.sh
+      BUILDSHREPOSITORY=$buildsh_repository
+    fi
+    if [ -n "$buildsh_revision" ]; then
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$BUILDSHREPOSITORY/$buildsh_revision/build.sh
+    else
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$BUILDSHREPOSITORY/$buildsh_branch/build.sh
     fi
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ fi
 
 VERSIONFILE=$ROOT/VERSION
 CHANGELOG=$ROOT/CHANGELOG
-CHANGELOGURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/CHANGELOG"
+CHANGELOGURL="https://raw.githubusercontent.com/$WUNDERTOOLSREPOSITORY/$GITBRANCH/CHANGELOG"
 
 if [ -f $VERSIONFILE ]; then
   typeset -i CURRENT_VERSION=$(<$VERSIONFILE)
@@ -134,10 +134,15 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
 
   # If it is enabled in project.yml - get & update drupal/build.sh
   if $buildsh_enabled; then
-    if [ -n "$buildsh_revision" ]; then
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/badrange/build.sh/$buildsh_revision/build.sh
+    if [ -z "$buildsh_repository" ]; then
+      WUNDERTOOLSREPOSITORY="wunderkraut/build.sh"
     else
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/badrange/build.sh/$buildsh_branch/build.sh
+      WUNDERTOOLSREPOSITORY=$buildsh_repository
+    fi
+    if [ -n "$buildsh_revision" ]; then
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$buildsh_repository/$buildsh_revision/build.sh
+    else
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$buildsh_repository/$buildsh_branch/build.sh
     fi
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -135,14 +135,14 @@ elif [[ $1 == "up" || $1 == "provision" ]]; then
   # If it is enabled in project.yml - get & update drupal/build.sh
   if $buildsh_enabled; then
     if [ -z "$buildsh_repository" ]; then
-      WUNDERTOOLSREPOSITORY="wunderkraut/build.sh"
+      BUILDSHREPOSITORY="wunderkraut/build.sh"
     else
-      WUNDERTOOLSREPOSITORY=$buildsh_repository
+      BUILDSHREPOSITORY=$buildsh_repository
     fi
     if [ -n "$buildsh_revision" ]; then
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$buildsh_repository/$buildsh_revision/build.sh
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$BUILDSHREPOSITORY/$buildsh_revision/build.sh
     else
-      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$buildsh_repository/$buildsh_branch/build.sh
+      curl -s -o $ROOT/drupal/build.sh https://raw.githubusercontent.com/$BUILDSHREPOSITORY/$buildsh_branch/build.sh
     fi
   fi
 

--- a/conf/project.yml
+++ b/conf/project.yml
@@ -9,8 +9,7 @@ buildsh:
   branch: develop
   revision:
 wundertools:
-  branch: feature/custom-wundertools-repository
-  repository: badrange/WunderTools
+  branch: master
 externaldrupal:
   remote:
   branch:

--- a/conf/project.yml
+++ b/conf/project.yml
@@ -9,7 +9,7 @@ buildsh:
   branch: develop
   revision:
 wundertools:
-  branch: master
+  branch: feature/custom-wundertools-repository
   repository: badrange/WunderTools
 externaldrupal:
   remote:

--- a/conf/project.yml
+++ b/conf/project.yml
@@ -10,6 +10,7 @@ buildsh:
   revision:
 wundertools:
   branch: master
+  repository: badrange/WunderTools
 externaldrupal:
   remote:
   branch:

--- a/conf/vagrant_local.yml
+++ b/conf/vagrant_local.yml
@@ -5,5 +5,5 @@ cpus : 2
 ip : 192.168.10.172
 box : "geerlingguy/centos7"
 # optional host aliases
-alias: local.alias.wundertools.com local.alias2.wundertools.com
+aliases: local.alias.wundertools.com local.alias2.wundertools.com
   

--- a/conf/vagrant_local.yml
+++ b/conf/vagrant_local.yml
@@ -4,3 +4,6 @@ mem : 2000
 cpus : 2
 ip : 192.168.10.172
 box : "geerlingguy/centos7"
+# optional host aliases
+alias: local.alias.wundertools.com local.alias2.wundertools.com
+  


### PR DESCRIPTION
I felt the need to avoid a situation where my colleagues and/or customers get asked all the time if they want to update or not, when running vagrant up etc. So I decided to have a fork for WunderTools, and then I also needed support in build.sh for checking my own repo for updates instead of your upstream. 

That change to conf/project.yml shouldn't be merged, of course, I only have it there for testing (this is a chicken and egg problem, really, can't test without it and shouldn't merge it..)
