### PR TITLE
Update local module and theme folder links to comply with default folder structure.

### DIFF
--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -45,8 +45,8 @@ local:
     - conf/composer.json: composer.json
     - conf/composer.lock: composer.lock
     - files: web/sites/default/files
-    - code/modules: web/modules/custom
-    - code/themes: web/themes/custom
+    - code/modules/custom: web/modules/custom
+    - code/themes/custom: web/themes/custom
     - sync: sync
 
   copy:


### PR DESCRIPTION
Module and theme folder links in local setup are not in sync with default folder structure of modules and themes under /drupal directory.