### PR TITLE
Updated error message and changed the box version to a working 1.1.3

### DIFF
--- a/conf/vagrant_local.yml
+++ b/conf/vagrant_local.yml
@@ -5,7 +5,9 @@ cpus : 2
 ip : 192.168.10.175
 box : "geerlingguy/centos7"
 #Check for newer box versions here: https://atlas.hashicorp.com/geerlingguy/boxes/centos7 
-box_version: 1.1.4
+#Box version is used for Virtualboxes only. WMWare does not have problems with the latest versions at this time
+#Version 1.1.4 is broken for virtualbox
+box_version: 1.1.3
 # optional host aliases
 aliases: local.alias.wundertools.com local.alias2.wundertools.com
   


### PR DESCRIPTION
Made the configuration file more informative that the box version is used for virtualbox only.
Fixed the default box version that was accidentally the broken version.