### PR TITLE
Use upcloud firewall with ansible

### DIFF
--- a/conf/production.yml
+++ b/conf/production.yml
@@ -1,5 +1,8 @@
 ---
 
+# Creates firewalls
+- include: upcloud.yml
+
 - include: prod-lb.yml
 - include: prod-db.yml
 - include: prod-front.yml

--- a/conf/production.yml
+++ b/conf/production.yml
@@ -1,6 +1,6 @@
 ---
 
-# Creates firewalls
+# Setup firewalls using upcloud api
 - include: upcloud.yml
 
 - include: prod-lb.yml

--- a/conf/stage.yml
+++ b/conf/stage.yml
@@ -1,7 +1,11 @@
 ---
 
-# Example of standard single server setup without production services (monitoring, logging etc.)
+# Creates firewalls for upcloud
+- hosts: localhost
+  roles:
+    - { role: upcloud-firewall, tags: ['upcloud','firewall'] }
 
+# Example of standard single server setup without production services (monitoring, logging etc.)
 - hosts: wundertools-stage
   become: false
   become_method: sudo

--- a/conf/stage.yml
+++ b/conf/stage.yml
@@ -1,9 +1,7 @@
 ---
 
-# Creates firewalls for upcloud
-- hosts: localhost
-  roles:
-    - { role: upcloud-firewall, tags: ['upcloud','firewall'] }
+# Setup firewalls using upcloud api
+- include: upcloud.yml
 
 # Example of standard single server setup without production services (monitoring, logging etc.)
 - hosts: wundertools-stage

--- a/conf/upcloud.yml
+++ b/conf/upcloud.yml
@@ -11,4 +11,4 @@
 # Creates firewalls for all machines
 - hosts: localhost
   roles:
-    - { role: upcloud-firewall, tags: ['upcloud','firewall'] }
+    - { role: upcloud-firewall, tags: ['upcloud', 'firewall'] }

--- a/conf/upcloud.yml
+++ b/conf/upcloud.yml
@@ -1,0 +1,4 @@
+# Creates firewalls for all machines
+- hosts: localhost
+  roles:
+    - { role: upcloud-firewall, tags: ['upcloud','firewall'] }

--- a/conf/upcloud.yml
+++ b/conf/upcloud.yml
@@ -1,3 +1,8 @@
+---
+##
+# This plabook configures Upcloud firewalls
+##
+
 # Login to machines to figure out private eth1 addresses too
 - hosts: all
   tasks:

--- a/conf/upcloud.yml
+++ b/conf/upcloud.yml
@@ -1,3 +1,8 @@
+# Login to machines to figure out private eth1 addresses too
+- hosts: all
+  tasks:
+    - meta: refresh_inventory
+
 # Creates firewalls for all machines
 - hosts: localhost
   roles:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Lock ansible version to have similiar experience for everyone
+ansible==2.2.1.0
+
+# This installs custom fork of upcloud-api
+# Which allows us to search machines with IP-addresses
+https://github.com/onnimonni/upcloud-python-api/archive/feature-get-machine-by-ip.zip#upcloud-api


### PR DESCRIPTION
Before this is useful we need to add `upcloud-firewall` role in [wunderkraut/WunderMachina](https://github.com/wunderkraut/WunderMachina) repository. See this PR: https://github.com/wunderkraut/WunderMachina/pull/137

To apply these changes for current project the inventory file needs to contain `upcloud_uuid` variables like this:
```
[wundertools-dev]
10.10.10.1 upcloud_uuid=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX

[wundertools-stage]
10.10.10.2 upcloud_uuid=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX

[wundertools-prod-db]
10.10.10.3 upcloud_uuid=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX

[wundertools-prod-lb]
10.10.10.4 upcloud_uuid=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX

[wundertools-prod-front]
10.10.10.5 upcloud_uuid=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
10.10.10.6 upcloud_uuid=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
```

Or we need to add the machines using dynamic inventory from: https://github.com/UpCloudLtd/upcloud-ansible/.