### PR TITLE
Feature/upcloud firewall management

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 roles_path=./local_ansible_roles:./ansible/playbook/roles
 hash_behaviour=merge
+library=.:./ansible/library

--- a/conf/ansible.cfg
+++ b/conf/ansible.cfg
@@ -1,4 +1,0 @@
-[defaults]
-roles_path=./local_ansible_roles:./ansible/playbook/roles
-hash_behaviour=merge
-library=.:./ansible/library

--- a/conf/ansible.cfg
+++ b/conf/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+roles_path=./local_ansible_roles:./ansible/playbook/roles
+hash_behaviour=merge
+library=.:./ansible/library

--- a/conf/upcloud.yml
+++ b/conf/upcloud.yml
@@ -1,0 +1,34 @@
+---
+##
+# This plabook configures Upcloud firewalls
+##
+
+# Make sure that the upcloud credentials are set as env
+- hosts: localhost
+  become: false
+  vars:
+    - upcloud_api_user: "{{ lookup('env', 'UPCLOUD_API_USER') }}"
+    - upcloud_api_passwd: "{{ lookup('env', 'UPCLOUD_API_PASSWD') }}"
+  tasks:
+    - name: Ensure that UPCLOUD_API_USER is present
+      fail:
+        msg: "You must set UPCLOUD_API_USER env"
+      when: upcloud_api_user == ""
+
+    - name: Ensure that UPCLOUD_API_PASSWD is present
+      fail:
+        msg: "You must set UPCLOUD_API_PASSWD env"
+      when: upcloud_api_passwd == ""
+
+# Login to machines to figure out private eth1 addresses too
+- hosts: all
+  user: root
+  tasks:
+    - meta: refresh_inventory
+
+# Creates firewalls for all machines
+- hosts: localhost
+  connection: local
+  become: false
+  roles:
+    - { role: upcloud-firewall, tags: ['upcloud', 'firewall'] }


### PR DESCRIPTION
Here some initial work on making upcloud-firewall role usable with provision.sh script. Kudos to @onnimonni for all the work.

Steps:
1. Get the latest upcloud-api Python library version:
```
cd /tmp
git clone https://github.com/UpCloudLtd/upcloud-python-api.git
cd upcloud-python-api 
python setup.py install
```
2. Define _vpn_ip_list_ and _deployment_server_ip_list_ variables in _variables.yml_ file with the Office, VPN, Deployment service and other IP addresses you might need.
```
vpn_ip_list:
  - xx.xxx.xxx.x
  - xx.xxx.xxx.x
deployment_server_ip_list:
  - xx.xxx.xxx.x
  - xx.xxx.xxx.x

```
3. Set UpCloud API user variables
```
export UPCLOUD_API_USER=username
export UPCLOUD_API_PASSWD=pass
```
4. Run provision
` ./provision.sh -t firewall upcloud`

This should result in the specified Firewall rules created in the UpCloud control panel