### PR TITLE
Added back the docs url served at docs.local.wundertools.com.

### DIFF
--- a/conf/vagrant.yml
+++ b/conf/vagrant.yml
@@ -77,7 +77,9 @@
       - server_name: "{{ domain_name }}"
         http_port: 8080
         docroot: /vagrant/drupal/web
-
+      - server_name: "docs.{{ domain_name}}"
+        http_port: 8082
+        docroot: /vagrant/docs
     # This server also acts as a load balancer
     varnish:
       port: 8081

--- a/conf/vagrant_local.yml
+++ b/conf/vagrant_local.yml
@@ -8,4 +8,4 @@ box: "geerlingguy/centos7"
 #Box version is used for Virtualboxes only. VMWare does not have problems with the latest versions at this time
 box_version: 1.2.0
 # optional host aliases
-aliases: local.alias.wundertools.com local.alias2.wundertools.com
+aliases: local.alias.wundertools.com local.alias2.wundertools.com docs.local.wundertools.com


### PR DESCRIPTION
Would be nice to have also an alias based on the hostname variable in vagrant_local.yml, but `docs.{{ hostname }}` didn't work.

thanks

fede