### PR TITLE
Separate initial project creation from setup of a new environment.

### DIFF
--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -43,6 +43,9 @@ default:
 
   local_commands:
     new:
+      - shell: echo "Use the 'create' command to create a new project and the 'reset' command to join an existing one."
+
+    create:
       - verify: "Type yes to verify you want to create a new installation: "
       - backup
       - make
@@ -86,7 +89,7 @@ test:
     #- conf/_ping.php: web/_ping.php
   # We can provide local commands or override global ones.
   local_commands:
-    new:
+    create:
       - shell: echo "Creating a new installation should only be done in local environments."
 
     reset:
@@ -143,7 +146,7 @@ production:
     - sync: sync
 
   local_commands:
-    new:
+    create:
       - shell: echo "Creating a new installation should only be done in local environments."
 
     reset:

--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -43,18 +43,22 @@ default:
 
   local_commands:
     new:
-      - verify: "Type yes to verify you want to build a new installation: "
+      - verify: "Type yes to verify you want to create a new installation: "
       - make
-      - backup
-      - install
-      - drush: cim
+      - drush: site-install standard
+      - drush: cex
+      - shell: echo "New installation is complete and configuration has been exported. Please commit it."
       - cleanup
 
+    reset:
+      - verify: "Type yes to verify you want to reset your local environment: "
+      - make
+      - drush: site-install config_installer
+      - cleanup
 
     # Basic site update functionality
     update:
       - make
-      - backup
       - update
       - drush: cim
       - drush: entity-updates
@@ -80,15 +84,13 @@ test:
   # We can provide local commands or override global ones.
   local_commands:
     new:
-      - verify: "Type yes to verify you want to build a new installation: "
-      - shell: chmod -R a+w web
-      - make
-      - backup
-      - install
-      - drush: cim
-      - cleanup
-      - shell: chmod -R a-w web
+      - shell: echo "Creating a new installation should only be done in local environments."
 
+    reset:
+      - verify: "Type yes to verify you want to reset your local environment: "
+      - make
+      - drush: site-install config_installer
+      - cleanup
 
     # Basic site update functionality
     update:
@@ -138,16 +140,13 @@ production:
 
   local_commands:
     new:
-      - verify: "Type yes to verify you want to build a new installation: "
-      - shell: chmod -R a+w current
+      - shell: echo "Creating a new installation should only be done in local environments."
+
+    reset:
+      - verify: "Type yes to verify you want to reset your local environment: "
       - make
-      - backup
-      - purge
-      - finalize
-      - install
-      - drush: cim
+      - drush: site-install config_installer
       - cleanup
-      - shell: chmod -R a-w current
 
 
     # Basic site update functionality

--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -44,6 +44,7 @@ default:
   local_commands:
     new:
       - verify: "Type yes to verify you want to create a new installation: "
+      - backup
       - make
       - drush: site-install standard
       - drush: cex
@@ -52,12 +53,14 @@ default:
 
     reset:
       - verify: "Type yes to verify you want to reset your local environment: "
+      - backup
       - make
       - drush: site-install config_installer
       - cleanup
 
     # Basic site update functionality
     update:
+      - backup
       - make
       - update
       - drush: cim
@@ -88,6 +91,7 @@ test:
 
     reset:
       - verify: "Type yes to verify you want to reset your local environment: "
+      - backup
       - make
       - drush: site-install config_installer
       - cleanup
@@ -95,8 +99,8 @@ test:
     # Basic site update functionality
     update:
       - shell: chmod -R a+w web
-      - make
       - backup
+      - make
       - update
       - drush: cim
       - drush: entity-updates
@@ -144,6 +148,7 @@ production:
 
     reset:
       - verify: "Type yes to verify you want to reset your local environment: "
+      - backup
       - make
       - drush: site-install config_installer
       - cleanup
@@ -152,8 +157,8 @@ production:
     # Basic site update functionality
     update:
       - shell: chmod -R a+w current
-      - make
       - backup
+      - make
       - finalize
       - update
       - drush: cim


### PR DESCRIPTION
Here's a proposal on how to address #144, some workarounds are needed to not require modifications to build.sh that wouldn't be compatible with older versions. 