### PR TITLE
Add base_pubkeys_host variable which we can populate from wundersecrets

### DIFF
--- a/conf/dev-vars.yml
+++ b/conf/dev-vars.yml
@@ -3,8 +3,9 @@
 # Note this file must be encrypted with ansible-vault!
 
 base_pubkeys_auth: username:password
-base_pubkeys_url: https://key.server.tld/auth?hostname={{ ansible_nodename }}
-base_addhost_url: https://key.server.tld/auth/add_server?hostname={{ ansible_nodename }}
+base_pubkeys_host: key.server.tld
+base_pubkeys_url: https://{{ base_pubkeys_host }}/auth?hostname={{ ansible_nodename }}
+base_addhost_url: https://{{ base_pubkeys_host }}/auth/add_server?hostname={{ ansible_nodename }}
 
 
 

--- a/conf/prod-vars.yml
+++ b/conf/prod-vars.yml
@@ -3,8 +3,9 @@
 # Note this file must be encrypted with ansible-vault!
 
 base_pubkeys_auth: username:password
-base_pubkeys_url: https://key.server.tld/auth?hostname={{ ansible_nodename }}
-base_addhost_url: https://key.server.tld/auth/add_server?hostname={{ ansible_nodename }}
+base_pubkeys_host: key.server.tld
+base_pubkeys_url: https://{{ base_pubkeys_host }}/auth?hostname={{ ansible_nodename }}
+base_addhost_url: https://{{ base_pubkeys_host }}/auth/add_server?hostname={{ ansible_nodename }}
 
 papertrail_host: "logs.host.tld"
 papertrail_port: 12345

--- a/conf/stage-vars.yml
+++ b/conf/stage-vars.yml
@@ -3,8 +3,9 @@
 # Note this file must be encrypted with ansible-vault!
 
 base_pubkeys_auth: username:password
-base_pubkeys_url: https://key.server.tld/auth?hostname={{ ansible_nodename }}
-base_addhost_url: https://key.server.tld/auth/add_server?hostname={{ ansible_nodename }}
+base_pubkeys_host: key.server.tld
+base_pubkeys_url: https://{{ base_pubkeys_host }}/auth?hostname={{ ansible_nodename }}
+base_addhost_url: https://{{ base_pubkeys_host }}/auth/add_server?hostname={{ ansible_nodename }}
 
 drupal_db_password: supersecret
 


### PR DESCRIPTION
`WunderSecrets/ansible.yml` can't contain any ansible magic in the variables.

To handle this hostname in WunderSecrets I added a new variable:
```yml
base_pubkeys_host: key.server.tld
```