### PR TITLE
I suppose config direcotry should be configured in settings.local.php…

### DIFF
--- a/drupal/conf/settings.local.php
+++ b/drupal/conf/settings.local.php
@@ -124,3 +124,9 @@ $settings['rebuild_access'] = TRUE;
  * directory.
  */
 $settings['skip_permissions_hardening'] = TRUE;
+
+/*
+ * Set configuration directory
+ */
+$config_directories['sync'] = '../sync';
+


### PR DESCRIPTION
…. We had a problem running build.sh reset without this, config_installer says:

_Exception: The configuration directory type 'sync' does not exist in /vagrant/drupal/web/core/includes/bootstrap.inc:163_