### PR TITLE
Fix error notices from drush aliases file in non-local environments

### DIFF
--- a/drupal/drush/wundertools.aliases.drushrc.php
+++ b/drupal/drush/wundertools.aliases.drushrc.php
@@ -6,11 +6,18 @@ array_pop($path);
 array_pop($path);
 $path[] = '.vagrant';
 $path = implode('/', $path);
-$key = shell_exec('find ' . $path . ' -iname private_key');
-if (!$key) {
-  $key = $home . '/.vagrant.d/insecure_private_key';
+
+// If the .vagrant folder exists find the ssh key for the virtual machine
+if ( file_exists($path) ) {
+  $key = shell_exec('find ' . $path . ' -iname private_key');
+  if (!$key) {
+    $key = $home . '/.vagrant.d/insecure_private_key';
+  }
+  $key = rtrim($key);
+} else {
+  // .vagrant directory doesn't exist, just use empty key
+  $key = "";
 }
-$key = rtrim($key);
 
 $aliases['local'] = array(
   'parent' => '@parent',


### PR DESCRIPTION
this change fixes annoying notices like these from the deploy logs:
```
find: ‘/var/www/client-project.com/releases/.vagrant’: No such file or directory
```