### PR TITLE
Add minimal Travis CI integration for client projects

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -1,0 +1,89 @@
+Instructions for using Travis CI
+================================
+
+Using [Travis CI](https://travis-ci.com) is really easy. Travis is free for open source projects and semi cheap for closed source client projects too.
+
+Travis CI is really useful because you can run any shell commands for testing the site before it is deployed and you can also run any shell commands to publis the site.
+
+How do install Travis CI cli-tools and authenticate to servers
+--------------------------------------------------------------
+Well first you need to have a Travis account which is linked to the Github organization.
+
+Then you need to install travis-cli tool:
+```
+$ gem install travis --no-rdoc --no-ri
+```
+
+And login to Travis CI Pro with your credentials
+```bash
+$ travis login --pro
+```
+
+How do I enable travis for my project?
+--------------------------------------
+
+You can enable travis by running
+```bash
+$ travis enable
+```
+
+You need to allow Travis CI to authenticate into the Servers. Every project in travis has unique ssh-key which you can use for authentication.
+```
+# Save travis public ssh key into travis.pub
+$ travis pubkey > travis.pub
+
+# Add travis.pub to authorized_keys of user www-admin. Remember to replace 100.100.100.100 with a real address
+$ ssh-copy-id -i travis.pub www-admin@100.100.100.100
+```
+
+**Note:** Also check that Travis container IP-addresses are allowed to connect from the firewall! These server IP-addresses can be found from their documentation: https://docs.travis-ci.com/user/ip-addresses/ 
+
+For closed source projects and client projects remember to allow `travis-ci.com` addresses.
+
+
+How do I do deployments with Travis?
+------------------------------------
+
+We have included example best practise configuration `.travis.yml` into this repo.
+
+You need to remove the project template `.travis.yml` from the root folder first:
+
+```bash
+$ rm .travis.yml
+$ git add .travis.yml
+$ git commit .travis.yml -m "Removed WunderTools .travis.yml"
+```
+
+And then you need to tell git to move the `.travis.yml` to the project root.
+```bash
+$ git mv drupal/.travis.yml .
+```
+
+To do automatic deployments with travis you need to update `.travis-extra.yml` file to your project root and fill in your server details. For example if your staging server is `100.100.100.100` and production server is `200.200.200.200` you would add them into `.travis-extra.yml` like this:
+
+```yml
+env:
+  branch:
+    master:
+      DEPLOY_HOST: 100.100.100.100
+      DEPLOY_BASE_PATH: /var/www/insert-folder-of-stage-sitename-here
+      DEPLOY_SITE_ENV: stage
+  branch:
+    production:
+      DEPLOY_HOST: 200.200.200.200
+      DEPLOY_BASE_PATH: /var/www/insert-folder-of-stage-sitename-here
+      DEPLOY_SITE_ENV: production
+```
+
+After you are ready you should commit changes to git and push them to git:
+
+```bash
+$ git add .travis-extra.yml
+$ git commit .travis* -m "Added travis testing and deployment"
+$ git push origin master
+```
+
+You can follow the build in Travis in real time:
+```
+$ travis open
+```

--- a/drupal/.travis.yml
+++ b/drupal/.travis.yml
@@ -1,0 +1,53 @@
+language: php
+php:
+  - '7.1'
+sudo: false
+cache:
+  directories:
+    - $HOME/.composer
+    - $HOME/.local
+env:
+  global:
+    # Few variables for the deploy target
+    - DEPLOY_VERSION=$(date +"%Y-%m-%d-%H-%M-%S")
+    - DEPLOY_USER=www-admin
+    # Use ci environment for drupal/build.sh
+    - WKV_SITE_ENV=ci
+    # Deploy these files
+    - DEPLOY_SRC=${TRAVIS_BUILD_DIR}/drupal
+    # Make pip installed libs available to python
+    - PYTHONPATH=${HOME}/.local/lib/python2.7/site-packages
+    # Use composer installed packages
+    - PATH="$HOME/.composer/vendor/bin:$PATH"
+install:
+  # Do not use PasswordAuthentication anywhere
+  - echo -e "Host *\n  PasswordAuthentication=no" >> ~/.ssh/config
+  # Install build.sh dependencies into Python virtualenv
+  - pip install pyyaml --user
+  # Install drush
+  - composer global require drush/drush
+  # Install imagick extensions
+  - printf "\n" | pecl install imagick
+  # Install travis-extra
+  - gem install travis-extra
+before_script:
+  # Enable custom branch based configs from .travis-extra.yml
+  - eval $(travis-extra --load-env)
+script:
+  # Install drupal components
+  - cd drupal
+  - ./build.sh build
+after_success:
+  # Deploy this site using Travis CI ssh key
+  # Trust the hostkey of the machine where this will be deployed
+  # Then rsync contents of current folder and symlink them to current build
+  - DEPLOY_PATH=${DEPLOY_BASE_PATH}/releases/${DEPLOY_VERSION};
+  - DEPLOY_CURRENT=${DEPLOY_BASE_PATH}/current;
+  - if [[ $TRAVIS_BRANCH =~ (develop|master|production) ]]; then
+        set -ex;
+        ssh-keyscan -H $DEPLOY_HOST >> ~/.ssh/known_hosts;
+        rsync -az --rsync-path="mkdir -p $DEPLOY_PATH && rsync" $DEPLOY_SRC/ ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/;
+        ssh ${DEPLOY_USER}@${DEPLOY_HOST} "cd ${DEPLOY_PATH} && ./build.sh update ${DEPLOY_SITE_ENV}";
+        ssh ${DEPLOY_USER}@${DEPLOY_HOST} "ln -sfn ${DEPLOY_PATH} ${DEPLOY_CURRENT}";
+        set +ex;
+    fi

--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -52,6 +52,16 @@ default:
         - vendor/bin/codecept clean -c web/codeception.yml
         - vendor/bin/codecept run -c web/codeception.yml
 
+# Allow doing minimal builds first in Travis CI
+# These can then be deployed to servers
+ci:
+  aliases: travis
+
+  local_commands:
+    build:
+      - make
+      - shell: chmod -R a+w web
+
 # Test environment:
 test:
 


### PR DESCRIPTION
This adds compatibility for [Travis CI](https://travis-ci.com).

Currently this is designed only to replace deploybot.com. So we have more control on the builds and that we could debug them more easily. I hope that we can also run the drupal web server in travis and run codeception tests before deploying anything. I'm really excited about this one :bowtie:!

What this does:
* Runs the `./build.sh build` in Travis CI instead of running it inside production servers
* If build wents well deploys contents of drupal folder to servers
	* develop -> dev servers
	* master -> stage servers
	* production -> production servers
* After transfering the files into servers it runs `./build.sh update $ENV` in the drupal folder.
* It mimicks Atomic SFTP of deploybot so it creates the releases folders and symlinks them to current folder.