### PR TITLE
Silta v1.0 components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  silta: silta/silta@0.1
+  silta: silta/silta@1
 
 workflows:
   version: 2

--- a/drupal/silta/nginx.Dockerfile
+++ b/drupal/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
-FROM wunderio/silta-nginx:v0.1
+FROM wunderio/silta-nginx:1.17-v1
 
 COPY . /app/web
 

--- a/drupal/silta/php.Dockerfile
+++ b/drupal/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/silta-php-fpm:v0.1
+FROM wunderio/silta-php-fpm:7.3-fpm-v1
 
 COPY --chown=www-data:www-data . /app
 

--- a/drupal/silta/shell.Dockerfile
+++ b/drupal/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/silta-php-shell:v0.1
+FROM wunderio/silta-php-shell:php7.3-v1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
Silta component adjustments to use v1.0 tags. There are no functional changes in this PR, 
image tags are pointed to the same images as before, but with v1.0 tags. 
From now on, Silta will aim to follow semantic versioning practices.
More information here: https://github.com/wunderio/silta/releases/tag/2023-10-03

Please review adjusted image tags and make sure this PR only changes relevant 
configuration files, feel free to make changes for components that have been left 
out from this PR.

This pull request was created with https://github.com/wunderio/internal-mass-updater.